### PR TITLE
Add Synapse::Error::Unknown

### DIFF
--- a/lib/synapse_api/error.rb
+++ b/lib/synapse_api/error.rb
@@ -34,6 +34,9 @@ module Synapse
     # Raised on the HTTP status code 503
     ServiceUnavailable = Class.new(ServerError)
 
+    # Raised on unexpected HTTP status codes
+    Unknown = Class.new(self)
+
     # HTTP status code to Error subclass mapping
     ERRORS = {
       '202' => Synapse::Error::Accepted,
@@ -65,7 +68,7 @@ module Synapse
       def from_response(body)
         message, error_code, http_code = parse_error(body)
         http_code = http_code.to_s
-        klass = ERRORS[http_code] || Synapse::Error
+        klass = ERRORS[http_code] || Synapse::Error::Unknown
         klass.new(message: message, code: error_code, response: body, http_code: http_code)
       end
 


### PR DESCRIPTION
While in production I ran into a 524 coming from CloudFlare.

```
Synapse::Error: <!DOCTYPE html>
<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->
<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]--
```

Rescuing from the more general `Synapse::Error` could lead to me missing a chance to deal with more specific errors in later parts of my response chain.

I propose returning `Synapse::Error::Unknown` rather than `Synapse::Error` as the default when an HTTP status code does not map to a known/expected value.