### PR TITLE
Rename duplicate User#get_node_statements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapseruby (1.0.4)
+    synapseruby (1.0.11)
       rest-client (~> 2.0)
 
 GEM
@@ -9,14 +9,15 @@ GEM
   specs:
     ansi (1.5.0)
     builder (3.2.3)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.2)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.1009)
     minitest (5.8.5)
     minitest-reporters (1.1.19)
       ansi
@@ -25,14 +26,16 @@ GEM
       ruby-progressbar
     netrc (0.11.0)
     rake (10.5.0)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     ruby-progressbar (1.10.0)
+    rubygems-update (3.0.6)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby
@@ -43,7 +46,8 @@ DEPENDENCIES
   minitest (~> 5.8.2)
   minitest-reporters (~> 1.1.5)
   rake (~> 10.0)
+  rubygems-update
   synapseruby!
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/lib/synapse_api/user.rb
+++ b/lib/synapse_api/user.rb
@@ -729,7 +729,7 @@ module Synapse
         # @param payload [Hash]
         # @see https://docs.synapsefi.com/reference#generate-node-statements
         # @return API response [Hash]
-        def get_node_statements(node_id:,payload:)
+        def generate_node_statements(node_id:,payload:)
 
             path = node(user_id: self.user_id, node_id: node_id) + "/statements"
 


### PR DESCRIPTION
`User#get_node_statements` was redeclared with a different method signature which breaks existing code and prevents the library from fetching the statements list. This PR updates the new method to be called `generate_node_statements`, reflecting its behavior.