### PR TITLE
Make user_id a keyword argument and optional to match internal implementation

### DIFF
--- a/lib/synapse_api/client.rb
+++ b/lib/synapse_api/client.rb
@@ -254,7 +254,7 @@ module Synapse
         # @param user_id [String] (Optional)
         # @see https://docs.synapsefi.com/docs/issuing-public-key
       	# @note valid scope "OAUTH|POST,USERS|POST,USERS|GET,USER|GET,USER|PATCH,SUBSCRIPTIONS|GET,SUBSCRIPTIONS|POST,SUBSCRIPTION|GET,SUBSCRIPTION|PATCH,CLIENT|REPORTS,CLIENT|CONTROLS"
-      	def issue_public_key(scope:, user_id = nil)
+      	def issue_public_key(scope:, user_id: nil)
       		path = '/client?issue_public_key=YES'
 
             path += "&scope=#{scope}"

--- a/lib/synapse_api/client.rb
+++ b/lib/synapse_api/client.rb
@@ -254,7 +254,7 @@ module Synapse
         # @param user_id [String] (Optional)
         # @see https://docs.synapsefi.com/docs/issuing-public-key
       	# @note valid scope "OAUTH|POST,USERS|POST,USERS|GET,USER|GET,USER|PATCH,SUBSCRIPTIONS|GET,SUBSCRIPTIONS|POST,SUBSCRIPTION|GET,SUBSCRIPTION|PATCH,CLIENT|REPORTS,CLIENT|CONTROLS"
-      	def issue_public_key(scope:, user_id)
+      	def issue_public_key(scope:, user_id = nil)
       		path = '/client?issue_public_key=YES'
 
             path += "&scope=#{scope}"


### PR DESCRIPTION
- Since the implementation of `user_id` here is optional, the signature should also make the `user_id` param be optional. Not allowing it to be optional is breaking one of my projects.

Also, modified it and changed it to be a keyword parameter. It was implemented as a required parameter previously, which should come before keyword arguments. Doing it this way keeps the order, and allows us to default the value to `nil` since it's an optional parameter.
https://stackoverflow.com/a/20633975/4163268